### PR TITLE
feat(params): update regex to match functions with parameters

### DIFF
--- a/fn.js
+++ b/fn.js
@@ -1,5 +1,5 @@
 
-var fnDecl = /^[ ]*function[ ]?\(\)[ ]?\{\n?/m,
+var fnDecl = /^[ ]*function[ ]?\(.*\)[ ]?\{\n?/m,
     trailingBrace = /[ ]*\}(?![\s\S]*\})$/m;
 
 module.exports = function (fn) {

--- a/test.js
+++ b/test.js
@@ -2,3 +2,6 @@ var assert = require('assert');
 var fnBody = require('./fn');
 
 assert.equal(fnBody(function () {yo()}), 'yo()');
+assert.equal(fnBody(function (argument) {yo()}), 'yo()');
+assert.equal(fnBody(function($scope) {yo()}), 'yo()');
+assert.equal(fnBody(function($scope, argument) {yo()}), 'yo()');


### PR DESCRIPTION
Previously the regex only matched `function () {` as the beginning function declaration.
Now function declarations like `function (argument) {` are also detected.
