### PR TITLE
feat(namedFunction): update regex to match named functions

### DIFF
--- a/fn.js
+++ b/fn.js
@@ -1,5 +1,5 @@
 
-var fnDecl = /^[ ]*function[ ]?\(.*\)[ ]?\{\n?/m,
+var fnDecl = /^[ ]*function[ ]?.*\(.*\)[ ]?\{\n?/m,
     trailingBrace = /[ ]*\}(?![\s\S]*\})$/m;
 
 module.exports = function (fn) {

--- a/test.js
+++ b/test.js
@@ -5,3 +5,4 @@ assert.equal(fnBody(function () {yo()}), 'yo()');
 assert.equal(fnBody(function (argument) {yo()}), 'yo()');
 assert.equal(fnBody(function($scope) {yo()}), 'yo()');
 assert.equal(fnBody(function($scope, argument) {yo()}), 'yo()');
+assert.equal(fnBody(function namedFunction($scope) {yo()}), 'yo()');


### PR DESCRIPTION
Previously the regex matched `function (args)` when matching the function declaration
to retrieve the body. Now functions declared like `function namedFunction(args)` can
also be identified correctly.
